### PR TITLE
Print leading zeros in uptime func

### DIFF
--- a/src/Commander-API-Commands.cpp
+++ b/src/Commander-API-Commands.cpp
@@ -73,7 +73,7 @@ void commander_uptime_func( char *args, Stream *response ){
   minute = second / 60;
   second %= 60;
 
-  sprintf( buff, "%d days, %d:%d:%lu", day, hour, minute, second );
+  sprintf( buff, "%d days, %d:%02d:%02lu", day, hour, minute, second );
 
   response -> print( buff );
 


### PR DESCRIPTION
The `uptime` built-in command would print something like `0 days, 0:3:2`, whereas I think `0 days, 0:03:02` is better.

`dev` seems to be one commit behind, so I'm targeting `master`. Let me know if you want me to change that.

<hr>

I was also a little scared of the 20 character buffer - I did some calculations and it seems like `sizeof "49 days, 17:02:47"` is 18, so it should be ok. I would use `snprintf(buff, sizeof buff, ...);` if this was my code, just to be sure. It is slower though.