### PR TITLE
Refactor use of F() macro to simplify `#ifdef`s

### DIFF
--- a/src/Commander-API-Commands.cpp
+++ b/src/Commander-API-Commands.cpp
@@ -33,6 +33,13 @@ SOFTWARE.
 
 #include "Commander-API-Commands.hpp"
 
+#if defined(ARDUINO) && defined(__AVR__)
+#define FF(s) F(s)
+#else
+#define FF(s) (s)
+#endif
+
+
 void commander_millis_func( char *args, Stream *response ){
 
   char buff[ 20 ];
@@ -92,27 +99,13 @@ void commander_pinMode_func( char *args, Stream *response ){
   argResult = sscanf( args, "%d %d", &pin, &direction );
 
   if( argResult != 2 ){
-
-    #ifdef __AVR__
-    response -> print( F( "Argument error!" ) );
-    #else
-    response -> print( (const char*)"Argument error!" );
-    #endif
-
+    response -> print( FF( "Argument error!" ) );
     return;
-
   }
 
   if( pin < 0 || direction < 0 ){
-
-    #ifdef __AVR__
-    response -> print( F( "Argument error!" ) );
-    #else
-    response -> print( (const char*)"Argument error!" );
-    #endif
-
+    response -> print( FF( "Argument error!" ) );
     return;
-
   }
 
   if( direction == 0 ){
@@ -128,13 +121,7 @@ void commander_pinMode_func( char *args, Stream *response ){
   }
 
   else{
-
-    #ifdef __AVR__
-    response -> print( F( "Argument error! Second argument has to be 1 or 0!" ) );
-    #else
-    response -> print( (const char*)"Argument error! Second argument has to be 1 or 0!" );
-    #endif
-
+    response -> print( FF( "Argument error! Second argument has to be 1 or 0!" ) );
   }
 
 }
@@ -150,24 +137,14 @@ void commander_digitalWrite_func( char *args, Stream *response ){
 
   if( argResult != 2 ){
 
-    #ifdef __AVR__
-    response -> print( F( "Argument error!" ) );
-    #else
-    response -> print( (const char*)"Argument error!" );
-    #endif
-
+    response -> print( FF( "Argument error!" ) );
     return;
 
   }
 
   if( pin < 0 || state < 0 ){
 
-    #ifdef __AVR__
-    response -> print( F( "Argument error!" ) );
-    #else
-    response -> print( (const char*)"Argument error!" );
-    #endif
-
+    response -> print( FF( "Argument error!" ) );
     return;
 
   }
@@ -185,13 +162,7 @@ void commander_digitalWrite_func( char *args, Stream *response ){
   }
 
   else{
-
-    #ifdef __AVR__
-    response -> print( F( "Argument error! Second argument has to be 1 or 0!" ) );
-    #else
-    response -> print( (const char*)"Argument error! Second argument has to be 1 or 0!" );
-    #endif
-
+    response -> print( FF( "Argument error! Second argument has to be 1 or 0!" ) );
   }
 
 }
@@ -205,27 +176,13 @@ void commander_digitalRead_func( char *args, Stream *response ){
   argResult = sscanf( args, "%d", &pin );
 
   if( argResult != 1 ){
-
-    #ifdef __AVR__
-    response -> print( F( "Argument error!" ) );
-    #else
-    response -> print( (const char*)"Argument error!" );
-    #endif
-
+    response -> print( FF( "Argument error!" ) );
     return;
-
   }
 
   if( pin < 0 ){
-
-    #ifdef __AVR__
-    response -> print( F( "Argument error!" ) );
-    #else
-    response -> print( (const char*)"Argument error!" );
-    #endif
-
+    response -> print( FF( "Argument error!" ) );
     return;
-
   }
 
   response -> print( digitalRead( pin ) );
@@ -378,14 +335,14 @@ void commander_analogRead_func( char *args, Stream *response ){
 
   if( argResult != 1 ){
 
-    response -> print( (const char*)"Argument error!" );
+    response -> print( "Argument error!" );
     return;
 
   }
 
   if( pin < 0 ){
 
-    response -> print( (const char*)"Argument error!" );
+    response -> print( "Argument error!" );
     return;
 
   }
@@ -400,24 +357,24 @@ void commander_analogRead_func( char *args, Stream *response ){
 
 void commander_ipconfig_func( char *args, Stream *response ){
 
-  response -> println( (const char*)"Wi-Fi:\r\n" );
+  response -> println( "Wi-Fi:\r\n" );
 
-  response -> print( (const char*)"\tIP Address  . . : " );
+  response -> print( "\tIP Address  . . : " );
   response -> println( WiFi.localIP() );
 
-  response -> print( (const char*)"\tSubnet Mask . . : " );
+  response -> print( "\tSubnet Mask . . : " );
   response -> println( WiFi.subnetMask() );
 
-  response -> print( (const char*)"\tDefault Gateway : " );
+  response -> print( "\tDefault Gateway : " );
   response -> println( WiFi.gatewayIP() );
 
 }
 
 void commander_wifiStat_func( char *args, Stream *response ){
 
-  response -> println( (const char*)"Wi-Fi:\r\n" );
+  response -> println( "Wi-Fi:\r\n" );
 
-  response -> print( (const char*)"\tMode: " );
+  response -> print( "\tMode: " );
 
   switch( WiFi.getMode() ){
 
@@ -461,11 +418,11 @@ void commander_wifiStat_func( char *args, Stream *response ){
 
   }
 
-  response -> print( (const char*)"\tRSSI: " );
+  response -> print( "\tRSSI: " );
   response -> print( WiFi.RSSI() );
   response -> println( "dBm" );
 
-  response -> print( (const char*)"\tMAC : " );
+  response -> print( "\tMAC : " );
   response -> println( WiFi.macAddress() );
 
 }
@@ -476,11 +433,11 @@ void commander_wifiScan_func( char *args, Stream *response ){
   int i;
   bool hasLocked = false;
 
-  response -> print( (const char*)"Scanning for available networks... " );
+  response -> print( "Scanning for available networks... " );
 
   num = WiFi.scanNetworks();
 
-  response -> println( (const char*)"[ OK ]:" );
+  response -> println( "[ OK ]:" );
 
   for( i = 0; i < num; i++ ){
 
@@ -519,7 +476,7 @@ void commander_wifiScan_func( char *args, Stream *response ){
   }
 
   if( hasLocked ){
-    response -> print( (const char*)"\r\n * means closed network." );
+    response -> print( "\r\n * means closed network." );
   }
 
 }
@@ -540,7 +497,7 @@ void commander_configTime_func( char *args, Stream *response ){
   if( argResult == 3 ){
 
     configTime( gmtOffset_sec, daylightOffset_sec, ntpServer );
-    response -> print( (const char*)"Time configured." );
+    response -> print( "Time configured." );
     return;
 
   }
@@ -549,15 +506,15 @@ void commander_configTime_func( char *args, Stream *response ){
 
   if( argResult == 2 ){
 
-    configTime( gmtOffset_sec, daylightOffset_sec, (const char*)"pool.ntp.org" );
-    response -> print( (const char*)"Time configured with default NTP server: pool.ntp.org" );
+    configTime( gmtOffset_sec, daylightOffset_sec, "pool.ntp.org" );
+    response -> print( "Time configured with default NTP server: pool.ntp.org" );
     return;
 
   }
 
   else{
 
-    response -> print( (const char*)"Argument error!" );
+    response -> print( "Argument error!" );
     return;
 
   }
@@ -794,11 +751,7 @@ void commander_neofetch_func( char *args, Stream *response ){
 
 void commander_reboot_func( char *args, Stream *response ){
 
-  #ifdef __AVR__
-  response -> println( F( "Rebooting..." ) );
-  #else
-  response -> println( (const char*)"Rebooting..." );
-  #endif
+  response -> println( FF( "Rebooting..." ) );
 
   #if defined( ESP32 ) || ( ESP8266 )
 
@@ -812,12 +765,6 @@ void commander_reboot_func( char *args, Stream *response ){
   #endif
 
 }
-
-#ifdef ARDUINO
-
-
-
-#endif
 
 
 void commander_sin_func( char *args, Stream *response ){
@@ -845,12 +792,7 @@ void commander_not_func( char *args, Stream *response ){
 
   if( argResult != 1 ){
 
-    #ifdef __AVR__
-    response -> print( F( "Argument error!" ) );
-    #else
-    response -> print( (const char*)"Argument error!" );
-    #endif
-
+    response -> print( FF( "Argument error!" ) );
     return;
 
   }
@@ -869,11 +811,7 @@ void commander_random_func( char *args, Stream *response ){
 
   if( argResult != 2 ){
 
-    #ifdef __AVR__
-    response -> print( F( "Argument error!" ) );
-    #else
-    response -> print( (const char*)"Argument error!" );
-    #endif
+    response -> print( FF( "Argument error!" ) );
 
     return;
 
@@ -881,11 +819,7 @@ void commander_random_func( char *args, Stream *response ){
 
   if( min >= max ){
 
-    #ifdef __AVR__
-    response -> print( F( "Argument erro! First argument is min, second is max!" ) );
-    #else
-    response -> print( (const char*)"Argument erro! First argument is min, second is max!" );
-    #endif
+    response -> print( FF( "Argument erro! First argument is min, second is max!" ) );
 
     return;
 

--- a/src/Commander-API-Commands.cpp
+++ b/src/Commander-API-Commands.cpp
@@ -385,11 +385,11 @@ void commander_wifiStat_func( char *args, Stream *response ){
       break;
 
     case WIFI_MODE_AP:
-      response -> println( "Acces Point" );
+      response -> println( "Access Point" );
       break;
 
     case WIFI_MODE_APSTA:
-      response -> println( "Acces Point & Station" );
+      response -> println( "Access Point & Station" );
       break;
 
     #endif
@@ -401,11 +401,11 @@ void commander_wifiStat_func( char *args, Stream *response ){
       break;
 
     case WIFI_AP:
-      response -> println( "Acces Point" );
+      response -> println( "Access Point" );
       break;
 
     case WIFI_AP_STA:
-      response -> println( "Acces Point & Station" );
+      response -> println( "Access Point & Station" );
       break;
 
     #endif
@@ -819,7 +819,7 @@ void commander_random_func( char *args, Stream *response ){
 
   if( min >= max ){
 
-    response -> print( FF( "Argument erro! First argument is min, second is max!" ) );
+    response -> print( FF( "Argument error! First argument is min, second is max!" ) );
 
     return;
 

--- a/src/Commander-API.cpp
+++ b/src/Commander-API.cpp
@@ -34,6 +34,12 @@ SOFTWARE.
 
 #include "Commander-API.hpp"
 
+#if defined(ARDUINO) && defined(__AVR__)
+#define FF(s) F(s)
+#else
+#define FF(s) (s)
+#endif
+
 const char *Commander::version = COMMANDER_API_VERSION;
 
 void Commander::attachTreeFunction( API_t *API_tree_p, uint32_t API_tree_size_p ){
@@ -42,27 +48,16 @@ void Commander::attachTreeFunction( API_t *API_tree_p, uint32_t API_tree_size_p 
 	API_tree      = API_tree_p;
 	API_tree_size = API_tree_size_p;
 
-	#if defined( ARDUINO ) && defined( __AVR__ )
-
-	dbgResponse -> print( F( "API tree attached with " ) );
+	dbgResponse -> print( FF( "API tree attached with " ) );
 	dbgResponse -> print( API_tree_size );
-	dbgResponse -> println( F( " commands." ) );
-
-	#else
-
-	dbgResponse -> print( (const char*)"API tree attached with "  );
-	dbgResponse -> print( API_tree_size );
-	dbgResponse -> println( " commands." );
-
-	#endif
-
+	dbgResponse -> println( FF( " commands." ) );
 }
 
 void Commander::init(){
 
 	// Generic conter variables.
 	uint32_t i;
-	uint32_t  j;
+	uint32_t j;
 
 	// Temporary variable, used to flip elements.
 	API_t temp;
@@ -82,26 +77,10 @@ void Commander::init(){
 
 	#endif
 
-	#if defined( ARDUINO ) && defined( __AVR__ )
-
-	dbgResponse -> println( F( "Commander init start" ) );
-
-	#else
-
-	dbgResponse -> println( (const char*)"Commander init start" );
-
-	#endif
+	dbgResponse -> println( FF( "Commander init start" ) );
 
 	// Make the tree ordered by alphabet.
-	#if defined( ARDUINO ) && defined( __AVR__ )
-
-	dbgResponse -> print( F( "  Creating alphabetical order... " ) );
-
-	#else
-
-	dbgResponse -> print( (const char*)"  Creating alphabetical order... " );
-
-	#endif
+	dbgResponse -> print( FF( "  Creating alphabetical order... " ) );
 
 	// Bubble sort. We need to sort the commands into an alphabetical order.
 	for( i = 0; i < API_tree_size; i++ ){
@@ -128,42 +107,16 @@ void Commander::init(){
 
 	}
 
-	#if defined( ARDUINO ) && defined( __AVR__ )
-
-	dbgResponse -> println( F( "[ OK ]" ) );
-
-	#else
-
-	dbgResponse -> println( (const char*)"[ OK ]" );
-
-	#endif
-
+	dbgResponse -> println( FF( "[ OK ]" ) );
 
 	// Optimize the tree to make it balanced.
 	// It is necessary to speed up the command
 	// search phase.
-	#if defined( ARDUINO ) && defined( __AVR__ )
-
-	dbgResponse -> print( F( "  Create balanced binary structure... " ) );
-
-	#else
-
-	dbgResponse -> print( (const char*)"  Create balanced binary structure... " );
-
-	#endif
+	dbgResponse -> print( FF( "  Create balanced binary structure... " ) );
 	optimize_api_tree();
 
-	#if defined( ARDUINO ) && defined( __AVR__ )
-
-	dbgResponse -> println( F( "[ OK ]" ) );
-	dbgResponse -> println( F( "Commander init finished!" ) );
-
-	#else
-
-	dbgResponse -> println( (const char*)"[ OK ]" );
-	dbgResponse -> println( (const char*)"Commander init finished!" );
-
-	#endif
+	dbgResponse -> println( FF( "[ OK ]" ) );
+	dbgResponse -> println( FF( "Commander init finished!" ) );
 
 }
 
@@ -492,19 +445,9 @@ void Commander::executeCommand( char *cmd, void* parent ){
 
 		// If we went through the whole tree and we did not found the command in it,
 		// we have to notice the user abut the problem. Maybe a Type-O
-		#if defined( ARDUINO ) && defined( __AVR__ )
-
-		response -> print( F( "Command \'" ) );
+		response -> print( FF( "Command \'" ) );
 		response -> print( tempBuff );
-		response -> println( F( "\' not found!" ) );
-
-		#else
-
-		response -> print( (const char*)"Command \'" );
-		response -> print( tempBuff );
-		response -> println( (const char*)"\' not found!" );
-
-		#endif
+		response -> println( FF( "\' not found!" ) );
 
 		#ifdef COMMANDER_ENABLE_PIPE_MODULE
 
@@ -668,31 +611,10 @@ void Commander::printHelp( Stream* out, bool description, bool style ){
 	uint32_t i;
 
 	if( style ){
-
-		#if defined( ARDUINO ) && defined( __AVR__ )
-
-		out -> println( F( "\033[1;31m----\033[1;32m Available commands \033[1;31m----\033[0;37m\r\n" ) );
-
-		#else
-
-		out -> println( (const char*)"\033[1;31m----\033[1;32m Available commands \033[1;31m----\033[0;37m\r\n" );
-
-		#endif
-
+		out -> println( FF( "\033[1;31m----\033[1;32m Available commands \033[1;31m----\033[0;37m\r\n" ) );
 	}
-
 	else{
-
-		#if defined( ARDUINO ) && defined( __AVR__ )
-
-		out -> println( F( "---- Available commands ----\r\n" ) );
-
-		#else
-
-		out -> println( (const char*)"---- Available commands ----\r\n" );
-
-		#endif
-
+		out -> println( FF( "---- Available commands ----\r\n" ) );
 	}
 
 	for( i = 0; i < API_tree_size; i++ ){
@@ -719,9 +641,9 @@ void Commander::printHelp( Stream* out, bool description, bool style ){
 
 				else if( memoryType == MEMORY_PROGMEM ){
 
-					out -> print( F( "\033[1;32m" ) );
+					out -> print( FF( "\033[1;32m" ) );
 					out -> print( API_tree[ find_api_index_by_place( i ) ].name_P );
-					out -> print( F( "\033[0;37m" ) );
+					out -> print( FF( "\033[0;37m" ) );
 					out -> print( ':' );
 					out -> print( ' ' );
 					out -> print( API_tree[ find_api_index_by_place( i ) ].desc_P );


### PR DESCRIPTION
This should make the code more readable with no change at all to the compiled binary. It should also make it easier to change these string literals in the future as there are no longer multiple occurrences that need changing.

The name of the new macro `FF()` is arbitrary, I just thought it should be short.

I also removed some unnecessary casts of string literals to `const char *`.

I was unable to test Commander-API-Commands because they seem to be broken at the `dev` branch.
```
error: invalid conversion from 'void (*)(char*, Stream*)' to 'void (*)(char*, Stream*, void*)' [-fpermissive]
```