### PR TITLE
Refactor `#ifdef`s in `Commander-API-Commands.cpp`

### DIFF
--- a/src/Commander-API-Commands.cpp
+++ b/src/Commander-API-Commands.cpp
@@ -586,6 +586,10 @@ void commander_reboot_func( char *args, Stream *response ){
   wdt_enable( WDTO_15MS );
   while( 1 );
 
+  #else
+
+  response -> println( FF( "Cannot reboot on this platform!" ) );
+
   #endif
 
 }

--- a/src/Commander-API-Commands.cpp
+++ b/src/Commander-API-Commands.cpp
@@ -189,7 +189,7 @@ void commander_digitalRead_func( char *args, Stream *response ){
 
 }
 
-#ifdef ARDUINO_AVR_UNO
+#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_LEONARDO) || defined( ESP32 ) || ( ESP8266 )
 
 void commander_analogRead_func( char *args, Stream *response ){
 
@@ -201,10 +201,21 @@ void commander_analogRead_func( char *args, Stream *response ){
 
   if( argResult != 1 ){
 
-    response -> print( F( "Argument error!" ) );
+    response -> print( FF( "Argument error!" ) );
     return;
 
   }
+
+  #if defined( ESP32 ) || ( ESP8266 )
+
+  if( pin < 0 ){
+
+    response -> print( FF( "Argument error!" ) );
+    return;
+
+  }
+
+  #else
 
   switch( pin ){
 
@@ -232,61 +243,7 @@ void commander_analogRead_func( char *args, Stream *response ){
       pin = A5;
       break;
 
-    default:
-      response -> print( F( "Argument error!" ) );
-      return;
-
-  }
-
-  response -> print( analogRead( pin ) );
-
-}
-
-#endif
-
-#ifdef ARDUINO_AVR_LEONARDO
-
-void commander_analogRead_func( char *args, Stream *response ){
-
-  int pin;
-
-  int argResult;
-
-  argResult = sscanf( args, "%d", &pin );
-
-  if( argResult != 1 ){
-
-    response -> print( F( "Argument error!" ) );
-    return;
-
-  }
-
-  switch( pin ){
-
-    case 0:
-      pin = A0;
-      break;
-
-    case 1:
-      pin = A1;
-      break;
-
-    case 2:
-      pin = A2;
-      break;
-
-    case 3:
-      pin = A3;
-      break;
-
-    case 4:
-      pin = A5;
-      break;
-
-    case 5:
-      pin = A5;
-      break;
-
+    #ifdef ARDUINO_AVR_LEONARDO
     case 6:
       pin = A6;
       break;
@@ -310,42 +267,14 @@ void commander_analogRead_func( char *args, Stream *response ){
     case 11:
       pin = A11;
       break;
+    #endif  // ARDUINO_AVR_LEONARDO
 
     default:
-      response -> print( F( "Argument error!" ) );
+      response -> print( FF( "Argument error!" ) );
       return;
 
   }
-
-  response -> print( analogRead( pin ) );
-
-}
-
-#endif
-
-#if defined( ESP32 ) || ( ESP8266 )
-
-void commander_analogRead_func( char *args, Stream *response ){
-
-  int pin;
-
-  int argResult;
-
-  argResult = sscanf( args, "%d", &pin );
-
-  if( argResult != 1 ){
-
-    response -> print( "Argument error!" );
-    return;
-
-  }
-
-  if( pin < 0 ){
-
-    response -> print( "Argument error!" );
-    return;
-
-  }
+  #endif
 
   response -> print( analogRead( pin ) );
 

--- a/src/Commander-API-Commands.cpp
+++ b/src/Commander-API-Commands.cpp
@@ -538,13 +538,11 @@ void commander_dateTime_func( char *args, Stream *response ){
 
 #endif
 
-#ifdef __AVR__
-
 void commander_neofetch_func( char *args, Stream *response ){
 
   uint32_t rowCounter = 0;
 
-  response -> print( F(
+  response -> print( FF(
       "\r\n\033[1;36m"
       "      :=*%@@@@%#+-             :=*%@@@@%#+-       \r\n"
       "    +%@@@@@@@@@@@@@#-       :*@@@@@@@@@@@@@@*:    \r\n"
@@ -560,194 +558,91 @@ void commander_neofetch_func( char *args, Stream *response ){
       "      -+#@@@@@@%*=:            -+#@@@@@@%*=.      \r\n"
       "\033[0;37m" ) );
 
-  response -> print( F( "\033[" ) );
+  response -> print( FF( "\033[" ) );
   response -> print( NEOFETCH_LOGO_HEIGHT );
-  response -> print( F( "A\033[51C" ) );
+  response -> print( FF( "A\033[51C" ) );
 
   #ifdef NEOFETCH_FW_NAME
-  response -> print( F( "\033[1;31mFW\033[0;37m: " ) );
-  response -> print( F( NEOFETCH_FW_NAME ) );
-  response -> print( F( "\r\n\033[51C" ) );
+  response -> print( FF( "\033[1;31mFW\033[0;37m: " ) );
+  response -> print( FF( NEOFETCH_FW_NAME ) );
+  response -> print( FF( "\r\n\033[51C" ) );
   rowCounter++;
   #endif
 
   #ifdef NEOFETCH_CPU_TYPE
-  response -> print( F( "\033[1;31mCPU\033[0;37m: " ) );
-  response -> print( F( NEOFETCH_CPU_TYPE ) );
-  response -> print( F( "\r\n\033[51C" ) );
+  response -> print( FF( "\033[1;31mCPU\033[0;37m: " ) );
+  response -> print( FF( NEOFETCH_CPU_TYPE ) );
+  response -> print( FF( "\r\n\033[51C" ) );
   rowCounter++;
   #endif
 
   #ifdef NEOFETCH_CPU_TYPE_AUTO
-  response -> print( F( "\033[1;31mCPU\033[0;37m: " ) );
+  response -> print( FF( "\033[1;31mCPU\033[0;37m: " ) );
 
   #ifdef ARDUINO_AVR_UNO
-  response -> print( F( "AVR - Arduino UNO" ) );
+  response -> print( FF( "AVR - Arduino UNO" ) );
   #elif ARDUINO_AVR_LEONARDO
-  response -> print( F( "AVR - Arduino Leonardo" ) );
+  response -> print( FF( "AVR - Arduino Leonardo" ) );
+  #elif ESP32
+  response -> print( FF( "ESP32" ) );
+  #elif ESP8266
+  response -> print( FF( "ESP8266" ) );
   #else
-  response -> print( F( "Unknown" ) );
+  response -> print( FF( "Unknown" ) );
   #endif
 
-  response -> print( F( "\r\n\033[51C" ) );
+  response -> print( FF( "\r\n\033[51C" ) );
   rowCounter++;
   #endif
 
   #ifdef NEOFETCH_COMPILER
-  response -> print( F( "\033[1;31mCompiler\033[0;37m: GCC " ) );
-  response -> print( F( NEOFETCH_COMPILER ) );
-  response -> print( F( "\r\n\033[51C" ) );
+  response -> print( FF( "\033[1;31mCompiler\033[0;37m: GCC " ) );
+  response -> print( FF( NEOFETCH_COMPILER ) );
+  response -> print( FF( "\r\n\033[51C" ) );
   rowCounter++;
   #endif
 
   #ifdef NEOFETCH_COMPILE_DATE
-  response -> print( F( "\033[1;31mCompile Date\033[0;37m: " ) );
-  response -> print( F( NEOFETCH_COMPILE_DATE ) );
-  response -> print( F( "\r\n\033[51C" ) );
+  response -> print( FF( "\033[1;31mCompile Date\033[0;37m: " ) );
+  response -> print( FF( NEOFETCH_COMPILE_DATE ) );
+  response -> print( FF( "\r\n\033[51C" ) );
   rowCounter++;
   #endif
 
   #ifdef NEOFETCH_TERMINAL
-  response -> print( F( "\033[1;31mTerminal\033[0;37m: " ) );
-  response -> print( F( NEOFETCH_TERMINAL ) );
-  response -> print( F( "\r\n\033[51C" ) );
+  response -> print( FF( "\033[1;31mTerminal\033[0;37m: " ) );
+  response -> print( FF( NEOFETCH_TERMINAL ) );
+  response -> print( FF( "\r\n\033[51C" ) );
   rowCounter++;
   #endif
 
   #ifdef NEOFETCH_COMMAND_PARSER
-  response -> print( F( "\033[1;31mCMD Parser\033[0;37m: " ) );
-  response -> print( F( NEOFETCH_COMMAND_PARSER ) );
-  response -> print( F( "\r\n\033[51C" ) );
+  response -> print( FF( "\033[1;31mCMD Parser\033[0;37m: " ) );
+  response -> print( FF( NEOFETCH_COMMAND_PARSER ) );
+  response -> print( FF( "\r\n\033[51C" ) );
   rowCounter++;
   #endif
 
   #ifdef NEOFETCH_AUTHOR
-  response -> print( F( "\033[1;31mAuthor\033[0;37m: " ) );
-  response -> print( F( NEOFETCH_AUTHOR ) );
-  response -> print( F( "\r\n\033[51C" ) );
+  response -> print( FF( "\033[1;31mAuthor\033[0;37m: " ) );
+  response -> print( FF( NEOFETCH_AUTHOR ) );
+  response -> print( FF( "\r\n\033[51C" ) );
   rowCounter++;
   #endif
 
   #ifdef NEOFETCH_LICENSE
-  response -> print( F( "\033[1;31mLicense\033[0;37m: " ) );
-  response -> print( F( NEOFETCH_LICENSE ) );
-  response -> print( F( "\r\n\033[51C" ) );
+  response -> print( FF( "\033[1;31mLicense\033[0;37m: " ) );
+  response -> print( FF( NEOFETCH_LICENSE ) );
+  response -> print( FF( "\r\n\033[51C" ) );
   rowCounter++;
   #endif
 
-  response -> print( F( "\033[" ) );
+  response -> print( FF( "\033[" ) );
   response -> print( NEOFETCH_LOGO_HEIGHT - rowCounter );
   response -> print( 'B' );
 
 }
 
-#else
-
-const char* neofetchLogo = {
-  "\r\n\033[1;36m"
-  "      :=*%@@@@%#+-             :=*%@@@@%#+-       \r\n"
-  "    +%@@@@@@@@@@@@@#-       :*@@@@@@@@@@@@@@*:    \r\n"
-  "  =@@@@@*=-:::-+#@@@@@=   :#@@@@%*=::::-+%@@@@#.  \r\n"
-  " *@@@@-          .=@@@@%:*@@@@*:          .#@@@@. \r\n"
-  "+@@@%               +@@@@@@@%:     .##      +@@@% \r\n"
-  "@@@@-   .+++++++     -@@@@@*     -+*@@++-    @@@@:\r\n"
-  "@@@@-   .+++++++     .%@@@@+     =+*@@*+-    %@@@:\r\n"
-  "*@@@#               =@@@@@@@#.     .##      -@@@@ \r\n"
-  " #@@@%:           -%@@@@=#@@@@+.           +@@@@: \r\n"
-  "  *@@@@%=:.   :-*@@@@@*   -%@@@@#=:.  .:-*@@@@%:  \r\n"
-  "   :*@@@@@@@@@@@@@@@+.      -#@@@@@@@@@@@@@@%=    \r\n"
-  "      -+#@@@@@@%*=:            -+#@@@@@@%*=.      \r\n"
-  "\033[0;37m"
-};
-
-void commander_neofetch_func( char *args, Stream *response ){
-
-  uint32_t rowCounter = 0;
-
-  response -> print( neofetchLogo );
-
-  response -> print( "\033[" );
-  response -> print( NEOFETCH_LOGO_HEIGHT );
-  response -> print( "A\033[51C" );
-
-  #ifdef NEOFETCH_FW_NAME
-  response -> print( "\033[1;31mFW\033[0;37m: " );
-  response -> print( NEOFETCH_FW_NAME );
-  response -> print( "\r\n\033[51C" );
-  rowCounter++;
-  #endif
-
-  #ifdef NEOFETCH_CPU_TYPE
-  response -> print( "\033[1;31mCPU\033[0;37m: " );
-  response -> print( NEOFETCH_CPU_TYPE );
-  response -> print( "\r\n\033[51C" );
-  rowCounter++;
-  #endif
-
-  #ifdef NEOFETCH_CPU_TYPE_AUTO
-  response -> print( "\033[1;31mCPU\033[0;37m: " );
-
-  #ifdef ESP32
-  response -> print( "ESP32" );
-  #elif ESP8266
-  response -> print( "ESP8266" );
-  #else
-  response -> print( "Unknown" );
-  #endif
-
-  response -> print( "\r\n\033[51C" );
-  rowCounter++;
-  #endif
-
-  #ifdef NEOFETCH_COMPILER
-  response -> print( "\033[1;31mCompiler\033[0;37m: GCC " );
-  response -> print( NEOFETCH_COMPILER );
-  response -> print( "\r\n\033[51C" );
-  rowCounter++;
-  #endif
-
-  #ifdef NEOFETCH_COMPILE_DATE
-  response -> print( "\033[1;31mCompile Date\033[0;37m: " );
-  response -> print( NEOFETCH_COMPILE_DATE );
-  response -> print( "\r\n\033[51C" );
-  rowCounter++;
-  #endif
-
-  #ifdef NEOFETCH_TERMINAL
-  response -> print( "\033[1;31mTerminal\033[0;37m: " );
-  response -> print( NEOFETCH_TERMINAL );
-  response -> print( "\r\n\033[51C" );
-  rowCounter++;
-  #endif
-
-  #ifdef NEOFETCH_COMMAND_PARSER
-  response -> print( "\033[1;31mCMD Parser\033[0;37m: " );
-  response -> print( NEOFETCH_COMMAND_PARSER );
-  response -> print( "\r\n\033[51C" );
-  rowCounter++;
-  #endif
-
-  #ifdef NEOFETCH_AUTHOR
-  response -> print( "\033[1;31mAuthor\033[0;37m: " );
-  response -> print( NEOFETCH_AUTHOR );
-  response -> print( "\r\n\033[51C" );
-  rowCounter++;
-  #endif
-
-  #ifdef NEOFETCH_LICENSE
-  response -> print( "\033[1;31mLicense\033[0;37m: " );
-  response -> print( NEOFETCH_LICENSE );
-  response -> print( "\r\n\033[51C" );
-  rowCounter++;
-  #endif
-
-  response -> print( "\033[" );
-  response -> print( NEOFETCH_LOGO_HEIGHT - rowCounter );
-  response -> print( "B" );
-
-}
-
-#endif
 
 void commander_reboot_func( char *args, Stream *response ){
 


### PR DESCRIPTION
This is a followup to https://github.com/dani007200964/Commander-API/pull/20 with some more aggressive changes.

The changes I made to `commander_analogRead_func` make it less readable, so feel free to cherry-pick only the commits you want.

### Testing
I was unable to test my changes directly due to the following error (not caused by this PR):
```
error: invalid conversion from 'void (*)(char*, Stream*)' to 'void (*)(char*, Stream*, void*)' [-fpermissive]
```

However, I was able to do it by using my new `Commander-API-Commands.cpp` with the rest of the repo from the master branch.

### `commander_reboot_func`
I have added an error message to it that warns the user at runtime if reboot is not available on that platform (e.g. STM32). However, there are other options:
1. message printed at runtime (current implementation)
2. compile-time `#warning`
3. `#ifdef` around the whole function. This will cause a linker error if unavailable, similar to `commander_analogRead_func` (but unlike `commander_configTime_func`, which also has `#ifdef` guards in `Commander-API-Commands.hpp` that prevent it from even defining the corresponding `API_ELEMENT_`.
4. `#ifdef` around the whole  function and the `API_ELEMENT_` definition (similar to `commandr_configTime_func`)

Let me know which one you prefer, I will update this PR. Until then, I will make it a draft.